### PR TITLE
Update GetProcessor.php

### DIFF
--- a/core/src/Revolution/Processors/Model/GetProcessor.php
+++ b/core/src/Revolution/Processors/Model/GetProcessor.php
@@ -28,7 +28,7 @@ abstract class GetProcessor extends ModelProcessor
 
     /**
      * {@inheritDoc}
-     * @return boolean
+     * @return boolean|string
      */
     public function initialize()
     {


### PR DESCRIPTION
### What does it do?
fix return type in processor

### Why is it needed?
initialize method GetProcessor can return bool if all ok or string if has errors.
